### PR TITLE
update readme. attempts at other improvements

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ jobs:
           git config --global user.email 'github-actions@github.com'
 
       - name: Install dependencies
-        run: npm i
+        run: npm ci
         working-directory: frontend
 
       - name: Deploy

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ jobs:
           git config --global user.email 'github-actions@github.com'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm i
         working-directory: frontend
 
       - name: Deploy

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 .binpath
+.env
 .metahash
 frontend/.env
 frontend/node_modules

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,7 @@ dependencies = [
  "gear-wasm-builder",
  "gmeta",
  "gstd",
+ "gtest",
  "mint-io",
 ]
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,11 @@
   sqd secrets:set RPC_ENDPOINT
   ```
 * Paste `wss://testnet-archive.vara.network`
-* Press CMD+D to save/exit
+* Press CTRL+D twice to save/exit (make sure you do it twice)
 * Check configured Subsquid CLI secrets
   ```sh
   sqd secrets:ls
   ```
-* Troubleshooting: It does not appear to read Subsquid secret that has been set with `sqd secrets:set RPC_ENDPOINT` and then pasting `wss://testnet-archive.vara.network` and pressing CTRL+D twice to save it. Due to this issue it was necessary to hard-code the URL in indexer/squid.yaml as `RPC_ENDPOINT: "wss://testnet-archive.vara.network"` for it to work
 * Change back to the project root directory, and then login to Subsquid Cloud using the Subsquid CLI using a script that reads your deployment key from the .env file. Note: This avoids the security risk of entering the deployment key directly in the terminal
   ```sh
   ./sqd-auth.sh
@@ -83,6 +82,7 @@
   sqd run .
   docker ps -a
   ```
+* Troubleshooting: If you get the following error `FATAL sqd:processor TypeError [ERR_INVALID_URL]: Invalid URL` when running the Subsquid project locally with the above commands, then it is likely unable to read the Subsquid secret that has been set with `sqd secrets:set RPC_ENDPOINT`. Try removing that secret with `sqd secrets rm RPC_ENDPOINT` and try carefully adding it again. If that does not work then try hard-coding the URL `RPC_ENDPOINT: "wss://testnet-archive.vara.network"` in indexer/squid.yaml to see if that works.
 * Troubleshooting: If you get an error `Error: connect ECONNREFUSED ::1:23798` then try stopping and removing the indexer Docker container by running `docker stop indexer-db-1 && docker rm indexer-db-1`, then try re-running the above commands again. If that still doesn't work, then try modifying the indexer/docker-composer.yml file before stopping and removing the indexer Docker container and re-running the above commands as follows:
   * Add `PGUSER: postgres`
   * Change `"${DB_PORT}:5432"` to `"127.0.0.1:${DB_PORT}:5432"`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [Prerequisites](#prerequisites)
 - [Quickstart](#quickstart)
 - [Contributing](#contributing)
+- [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
 
@@ -57,16 +58,16 @@
   ```sh
   source .env
   ```
-* Update Subsquid CLI secrets https://docs.subsquid.io/squid-cli/secrets/
+* **Production Only** Update Subsquid CLI secrets https://docs.subsquid.io/squid-cli/secrets/
   ```sh
   sqd secrets:set RPC_ENDPOINT
   ```
-* Paste `wss://testnet-archive.vara.network`
-* Press CTRL+D twice to save/exit (make sure you do it twice)
-* Check configured Subsquid CLI secrets
-  ```sh
-  sqd secrets:ls
-  ```
+  * Paste `wss://testnet-archive.vara.network`
+  * Press CTRL+D twice to save/exit (make sure you do it twice)
+  * Check configured Subsquid CLI secrets
+    ```sh
+    sqd secrets:ls
+    ```
 * Change back to the project root directory, and then login to Subsquid Cloud using the Subsquid CLI using a script that reads your deployment key from the .env file. Note: This avoids the security risk of entering the deployment key directly in the terminal
   ```sh
   ./sqd-auth.sh
@@ -82,11 +83,7 @@
   sqd run .
   docker ps -a
   ```
-* Troubleshooting: If you get the following error `FATAL sqd:processor TypeError [ERR_INVALID_URL]: Invalid URL` when running the Subsquid project locally with the above commands, then it is likely unable to read the Subsquid secret that has been set with `sqd secrets:set RPC_ENDPOINT`. Try removing that secret with `sqd secrets rm RPC_ENDPOINT` and try carefully adding it again. If that does not work then try hard-coding the URL `RPC_ENDPOINT: "wss://testnet-archive.vara.network"` in indexer/squid.yaml to see if that works.
-* Troubleshooting: If you get an error `Error: connect ECONNREFUSED ::1:23798` then try stopping and removing the indexer Docker container by running `docker stop indexer-db-1 && docker rm indexer-db-1`, then try re-running the above commands again. If that still doesn't work, then try modifying the indexer/docker-composer.yml file before stopping and removing the indexer Docker container and re-running the above commands as follows:
-  * Add `PGUSER: postgres`
-  * Change `"${DB_PORT}:5432"` to `"127.0.0.1:${DB_PORT}:5432"`
-* View  GraphiQL playground available at http://localhost:4350/graphql
+* View GraphiQL playground available at http://localhost:4350/graphql
 * Optional:
   * View Postgresql DB by entering the docker container's shell and running the following commands
     ```sh
@@ -116,3 +113,10 @@
 ## Contributing
 
 * Vara-Arena tasks: https://github.com/orgs/ImpulseDAO/projects/2/views/1
+
+## Troubleshooting
+
+* If you get the following error `FATAL sqd:processor TypeError [ERR_INVALID_URL]: Invalid URL` when running the Subsquid project locally with the above commands, then it is likely unable to read the Subsquid secret that has been set with `sqd secrets:set RPC_ENDPOINT`. Try removing that secret with `sqd secrets rm RPC_ENDPOINT` and try carefully adding it again. If that does not work then try hard-coding the URL `RPC_ENDPOINT: "wss://testnet-archive.vara.network"` in indexer/squid.yaml to see if that works.
+* If you get an error `Error: connect ECONNREFUSED ::1:23798` then try stopping and removing the indexer Docker container by running `docker stop indexer-db-1 && docker rm indexer-db-1`, then try re-running the above commands again. If that still doesn't work, then try modifying the indexer/docker-composer.yml file before stopping and removing the indexer Docker container and re-running the above commands as follows:
+  * Add `PGUSER: postgres`
+  * Change `"${DB_PORT}:5432"` to `"127.0.0.1:${DB_PORT}:5432"`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 ## Quickstart
 
+* Run the following in the project root directory
 * Install Rust and build
   ```sh
   RUST_NIGHTLY="2023-09-18"
@@ -52,7 +53,7 @@
   ```
 * Obtain Subsquid Cloud deployment key `DEPLOYMENT_KEY` from https://app.subsquid.io/
 * Add your Subsquid deployment key that you obtained from https://app.subsquid.io/squids as the value of `DEPLOYMENT_KEY` in the .env file
-* Source the .env file
+* Source the .env file to make the environment variables available in your terminal session
   ```sh
   source .env
   ```
@@ -66,8 +67,8 @@
   ```sh
   sqd secrets:ls
   ```
-* FIXME: It does not appear to read Subsquid secret that has been set with `sqd secrets:set RPC_ENDPOINT` and then pasting `wss://testnet-archive.vara.network` and pressing CTRL+D twice to save it. Due to this issue it was necessary to hard-code the URL in squid.yaml for it to work
-* Login to Subsquid Cloud using the Subsquid CLI using a script that reads your deployment key from the .env file. Note: This avoids the security risk of entering the deployment key directly in the terminal
+* Troubleshooting: It does not appear to read Subsquid secret that has been set with `sqd secrets:set RPC_ENDPOINT` and then pasting `wss://testnet-archive.vara.network` and pressing CTRL+D twice to save it. Due to this issue it was necessary to hard-code the URL in indexer/squid.yaml as `RPC_ENDPOINT: "wss://testnet-archive.vara.network"` for it to work
+* Change back to the project root directory, and then login to Subsquid Cloud using the Subsquid CLI using a script that reads your deployment key from the .env file. Note: This avoids the security risk of entering the deployment key directly in the terminal
   ```sh
   ./sqd-auth.sh
   ```
@@ -82,6 +83,9 @@
   sqd run .
   docker ps -a
   ```
+* Troubleshooting: If you get an error `Error: connect ECONNREFUSED ::1:23798` then try stopping and removing the indexer Docker container by running `docker stop indexer-db-1 && docker rm indexer-db-1`, then try re-running the above commands again. If that still doesn't work, then try modifying the indexer/docker-composer.yml file before stopping and removing the indexer Docker container and re-running the above commands as follows:
+  * Add `PGUSER: postgres`
+  * Change `"${DB_PORT}:5432"` to `"127.0.0.1:${DB_PORT}:5432"`
 * View  GraphiQL playground available at http://localhost:4350/graphql
 * Optional:
   * View Postgresql DB by entering the docker container's shell and running the following commands
@@ -102,6 +106,11 @@
   ```sh
   npm i
   npm run predeploy
+  ```
+* Note: If you want to stop and remove the indexer's Docker container then run:
+  ```sh
+  docker stop indexer-db-1
+  docker rm indexer-db-1
   ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@
 ## Quickstart
 
 * Install Rust and build
-```sh
-RUST_NIGHTLY="2023-09-18"
-rustup toolchain install "nightly-${RUST_NIGHTLY}" && \
-rustup component add rust-src rustfmt clippy --toolchain "nightly-${RUST_NIGHTLY}" && \
-rustup target add wasm32-unknown-unknown --toolchain "nightly-${RUST_NIGHTLY}" && \
-rustup toolchain install "nightly-${RUST_NIGHTLY}" --profile minimal --component rustfmt
-rustup default "nightly-${RUST_NIGHTLY}" && \
-rustup override set "nightly-${RUST_NIGHTLY}" && \
-cargo version && \
-rustc --version && \
-cargo test && \
-cargo install --git=https://github.com/rustwasm/wasm-pack && \
-cargo build --release
-```
+  ```sh
+  RUST_NIGHTLY="2023-09-18"
+  rustup toolchain install "nightly-${RUST_NIGHTLY}" && \
+  rustup component add rust-src rustfmt clippy --toolchain "nightly-${RUST_NIGHTLY}" && \
+  rustup target add wasm32-unknown-unknown --toolchain "nightly-${RUST_NIGHTLY}" && \
+  rustup toolchain install "nightly-${RUST_NIGHTLY}" --profile minimal --component rustfmt
+  rustup default "nightly-${RUST_NIGHTLY}" && \
+  rustup override set "nightly-${RUST_NIGHTLY}" && \
+  cargo version && \
+  rustc --version && \
+  cargo test && \
+  cargo install --git=https://github.com/rustwasm/wasm-pack && \
+  cargo build --release
+  ```
 * [Follow the Vara-Arena Indexer Instructions](./indexer/README.md)
 * Optional: Install Node.js without NVM and skip the next couple of steps that use NVM instead.
 * Install NVM https://nodejs.org/en/download/package-manager#nvm.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,109 @@
+# Vara-Arena
+
+## Summary
+
+- [Prerequisites](#prerequisites)
+- [Quickstart](#quickstart)
+- [Contributing](#contributing)
+
+## Prerequisites
+
+* Node 18.x
+* Docker
+* NPM -- note that `yarn` package manager is not supported
+* Rust Nightly 2023-09-18
+
+## Quickstart
+
+* Install Rust and build
+```sh
+RUST_NIGHTLY="2023-09-18"
+rustup toolchain install "nightly-${RUST_NIGHTLY}" && \
+rustup component add rust-src rustfmt clippy --toolchain "nightly-${RUST_NIGHTLY}" && \
+rustup target add wasm32-unknown-unknown --toolchain "nightly-${RUST_NIGHTLY}" && \
+rustup toolchain install "nightly-${RUST_NIGHTLY}" --profile minimal --component rustfmt
+rustup default "nightly-${RUST_NIGHTLY}" && \
+rustup override set "nightly-${RUST_NIGHTLY}" && \
+cargo version && \
+rustc --version && \
+cargo test && \
+cargo install --git=https://github.com/rustwasm/wasm-pack && \
+cargo build --release
+```
+* [Follow the Vara-Arena Indexer Instructions](./indexer/README.md)
+* Optional: Install Node.js without NVM and skip the next couple of steps that use NVM instead.
+* Install NVM https://nodejs.org/en/download/package-manager#nvm.
+   ```sh
+   wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+   ```
+* install Node.js 18 using NVM
+   ```sh
+   nvm install 18 && nvm use 18
+   ```
+* Install Subsquid https://docs.subsquid.io/squid-cli/installation/
+
+* Change directory into the indexer/ subdirectory
+  ```sh
+  cd indexer
+  ```
+* Generate .env file from .env.example
+  ```
+  cp .env.example .env
+  ```
+* Obtain Subsquid Cloud deployment key `DEPLOYMENT_KEY` from https://app.subsquid.io/
+* Add your Subsquid deployment key that you obtained from https://app.subsquid.io/squids as the value of `DEPLOYMENT_KEY` in the .env file
+* Source the .env file
+  ```sh
+  source .env
+  ```
+* Update Subsquid CLI secrets https://docs.subsquid.io/squid-cli/secrets/
+  ```sh
+  sqd secrets:set RPC_ENDPOINT
+  ```
+* Paste `wss://testnet-archive.vara.network`
+* Press CMD+D to save/exit
+* Check configured Subsquid CLI secrets
+  ```sh
+  sqd secrets:ls
+  ```
+* FIXME: It does not appear to read Subsquid secret that has been set with `sqd secrets:set RPC_ENDPOINT` and then pasting `wss://testnet-archive.vara.network` and pressing CTRL+D twice to save it. Due to this issue it was necessary to hard-code the URL in squid.yaml for it to work
+* Login to Subsquid Cloud using the Subsquid CLI using a script that reads your deployment key from the .env file. Note: This avoids the security risk of entering the deployment key directly in the terminal
+  ```sh
+  ./sqd-auth.sh
+  ```
+* Run the following in the indexer/ subdirectory:
+  ```sh
+  npm i -g @subsquid/cli@latest
+  sqd --version
+  sqd --help
+  npm i
+  sqd up
+  sqd build
+  sqd run .
+  docker ps -a
+  ```
+* View  GraphiQL playground available at http://localhost:4350/graphql
+* Optional:
+  * View Postgresql DB by entering the docker container's shell and running the following commands
+    ```sh
+    docker exec -it --user=root indexer-db-1 /bin/bash
+
+    root@565d0f87d4f6:/# pg_isready
+    /var/run/postgresql:5432 - accepting connections
+    root@565d0f87d4f6:/# psql -U postgres
+    postgres=# \l
+    ```
+
+* Open a new terminal window. Change to to frontend/ subdirectory.
+  ```sh
+  cd frontend
+  ```
+* Install dependencies and build the frontend:
+  ```sh
+  npm i
+  npm run predeploy
+  ```
+
+## Contributing
+
+* Vara-Arena tasks: https://github.com/orgs/ImpulseDAO/projects/2/views/1

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@
     ```sh
     docker exec -it --user=root indexer-db-1 /bin/bash
 
-    root@565d0f87d4f6:/# pg_isready
+    root@123:/# pg_isready
     /var/run/postgresql:5432 - accepting connections
-    root@565d0f87d4f6:/# psql -U postgres
+    root@123:/# psql -U postgres
     postgres=# \l
     ```
 

--- a/indexer/.env.example
+++ b/indexer/.env.example
@@ -13,3 +13,5 @@ RPC_ENDPOINT=wss://testnet-archive.vara.network
 # SQD_DEBUG=sqd:process
 
 MINT_COST=10
+
+DEPLOYMENT_KEY=

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -19,7 +19,7 @@ It accumulates [kusama](https://kusama.network) account transfers and serves the
 
 ## Prerequisites
 
-* node 16.x
+* node 18.x
 * docker
 * npm -- note that `yarn` package manager is not supported
 
@@ -30,7 +30,7 @@ Please [install](https://docs.subsquid.io/squid-cli/installation/) it before pro
 
 ```bash
 # 1. Install dependencies
-npm ci
+npm i
 
 # 2. Start target Postgres database and detach
 sqd up
@@ -58,9 +58,9 @@ To make sure you're indexing the right chain one can additionally filter by the 
 
 ```typescript
 processor.setDataSource({
-  archive: lookupArchive("kusama", { 
+  archive: lookupArchive("kusama", {
     release: "ArrowSquid",
-    genesis: "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe" 
+    genesis: "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe"
   }),
   //...
 });
@@ -108,7 +108,7 @@ npx squid-typeorm-migration create
 npx squid-typeorm-migration apply
 
 # Revert the last performed migration
-npx squid-typeorm-migration revert         
+npx squid-typeorm-migration revert
 ```
 Available `sqd` shortcuts:
 ```bash
@@ -119,12 +119,12 @@ sqd migration:generate
 sqd migration:apply
 ```
 
-### 4. Generate TypeScript definitions for substrate events, calls and storage 
+### 4. Generate TypeScript definitions for substrate events, calls and storage
 
-This is an optional part, but it is very advisable. 
+This is an optional part, but it is very advisable.
 
-Event, call and runtime storage data come to mapping handlers as raw untyped json. 
-While it is possible to work with raw untyped json data, 
+Event, call and runtime storage data come to mapping handlers as raw untyped json.
+While it is possible to work with raw untyped json data,
 it's extremely error-prone and the json structure may change over time due to runtime upgrades.
 
 Squid framework provides a tool for generating type-safe wrappers around events, calls and runtime storage items for
@@ -150,7 +150,7 @@ For more information, consult the [Deployment Guide](https://docs.subsquid.io/de
 
 Squid tools assume a certain project layout.
 
-* All compiled js files must reside in `lib` and all TypeScript sources in `src`. 
+* All compiled js files must reside in `lib` and all TypeScript sources in `src`.
 The layout of `lib` must reflect `src`.
 * All TypeORM classes must be exported by `src/model/index.ts` (`lib/model` module).
 * Database schema must be defined in `schema.graphql`.
@@ -161,10 +161,10 @@ See the [full desription](https://docs.subsquid.io/basics/squid-structure/) in t
 
 ## Types bundle
 
-Substrate chains that have blocks with metadata versions below 14 don't provide enough 
+Substrate chains that have blocks with metadata versions below 14 don't provide enough
 information to decode their data. For those chains, external [type](https://polkadot.js.org/docs/api/start/types.extend) [definitions](https://polkadot.js.org/docs/api/start/types.extend) are required.
 
-Subsquid tools include definitions for many chains, however sometimes external 
+Subsquid tools include definitions for many chains, however sometimes external
 definitions are still required.
 
 You can pass them as a special json file (types bundle) of the following structure:
@@ -206,12 +206,12 @@ those two are not fully compatible.
 
 ## Differences from polkadot.js
 
-Polkadot.js provides lots of [specialized classes](https://polkadot.js.org/docs/api/start/types.basics) for various types of data. 
+Polkadot.js provides lots of [specialized classes](https://polkadot.js.org/docs/api/start/types.basics) for various types of data.
 Even primitives like `u32` are exposed through special classes.
 In contrast, the squid framework works only with plain js primitives and objects.
 For instance, account data is passed to the handler context as a plain byte array.  To convert it into a standard human-readable format one should explicitly use a utility lib `@subsquid/ss58`:
 
-```typescript 
+```typescript
     // ...
     from: ss58.codec('kusama').encode(rec.from),
     to: ss58.codec('kusama').encode(rec.to),

--- a/indexer/docker-compose.yml
+++ b/indexer/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       POSTGRES_PASSWORD: postgres
     shm_size: 1gb
     ports:
-      - "${DB_PORT}:5432"
+      - "127.0.0.1:${DB_PORT}:5432"
       # command: ["postgres", "-c", "log_statement=all"]
-#    volumes:
-#      - ./data/db:/var/lib/postgresql/data
+      #    volumes:
+      #      - ./data/db:/var/lib/postgresql/data
 

--- a/indexer/docker-compose.yml
+++ b/indexer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: postgres
     shm_size: 1gb
     ports:
-      - "127.0.0.1:${DB_PORT}:5432"
+      - "${DB_PORT}:5432"
       # command: ["postgres", "-c", "log_statement=all"]
       #    volumes:
       #      - ./data/db:/var/lib/postgresql/data

--- a/indexer/sqd-auth.sh
+++ b/indexer/sqd-auth.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Configure the Subsquid CLI
+source .env
+sqd auth -k $DEPLOYMENT_KEY


### PR DESCRIPTION
* Adds a README file in the project root directory with instructions for contributors
* Add a .env.example file and include `DEPLOYMENT_KEY=` in it. User to create their own .env using it and populate the values so they do not push credentials to Github. Added .env to Gitignore file
* Fix instructions that say to use Node.js 16.x when it should be Node.js 18.x
* Added a indexer/sqd-auth.sh shell script that the user may run so they may authenticate with Subsquid without having to manually enter their Subsquid credentials into the shell, since that may pose a security risk